### PR TITLE
テンプレ一覧とテンプレ選択UI実装

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,0 +1,13 @@
+class TemplatesController < ApplicationController
+  before_action :authenticate_user!, only: [:select]
+
+  def index
+    @templates = Template.active
+  end
+
+  def select
+    # タブ切り替え用の kind パラメータ（デフォルトは便箋）
+    @kind = params[:kind].presence || 'stationery'
+    @templates = Template.active.where(kind: @kind)
+  end
+end

--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -1,3 +1,6 @@
 class TopPagesController < ApplicationController
-  def index; end
+  def index
+    @stationery_templates     = Template.active.stationery.limit(4)
+    @message_card_templates   = Template.active.message_cards.limit(4)
+  end
 end

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -1,0 +1,9 @@
+module TemplatesHelper
+  def template_aspect_class(template)
+    case template.kind
+    when "stationery"    then "aspect-[3/4]" # 縦
+    when "message_card"  then "aspect-[4/3]" # 横
+    else "aspect-[3/4]"
+    end
+  end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -30,6 +30,24 @@ class Template < ApplicationRecord
   scope :stationery, -> { where(kind: 'stationery') }
   scope :message_cards, -> { where(kind: 'message_card') }
 
+  #kindを日本語ラベルに変換(将来はi18n)
+  def kind_label
+    case kind
+    when 'stationery' then '便箋'
+    when 'message_card' then 'メッセージカード'
+    else kind
+    end
+  end
+
+  # 表示用の画像パスを返す（サムネイル優先 → なければ背景画像）
+  # &. (ぼっち演算子）は nil でもエラーにしない安全な呼び出し、dig も同様。
+  def display_image_path
+    return thumbnail_path if thumbnail_path.present?
+  
+    layout&.dig("background", "src")
+  end
+
+
   private
 
   # layout全体がHashかどうかと、canvas/background/placeholdersの有無・形式をまとめてチェック

--- a/app/views/templates/_card.html.erb
+++ b/app/views/templates/_card.html.erb
@@ -1,0 +1,24 @@
+<%# app/views/templates/_card.html.erb %>
+
+<div class="rounded-2xl border border-stone-200 bg-white p-3 shadow-sm hover:shadow-md transition">
+
+  <!-- サムネイル枠（縦長 / 横長は helper の aspect_class で定義） --> 
+  <div class="<%= template_aspect_class(template) %> w-full overflow-hidden rounded-xl mb-2 bg-stone-100">
+    <% if template.display_image_path.present? %>
+      <%= image_tag template.display_image_path,
+                    alt: template.title,
+                    class: "w-full h-full object-cover" %>
+    <% end %>
+  </div>
+
+  <!-- 種類ラベル（便箋 / メッセージカード） -->
+  <div class="text-[11px] text-stone-500 mb-1">
+    <%= template.kind_label %>
+  </div>
+
+  <!-- テンプレート名 -->
+  <div class="text-sm font-semibold text-stone-800 truncate">
+    <%= template.title %>
+  </div>
+
+</div>

--- a/app/views/templates/select.html.erb
+++ b/app/views/templates/select.html.erb
@@ -1,0 +1,44 @@
+<div class="max-w-6xl mx-auto px-4 py-8 flex gap-6">
+  <!-- サイドバー -->
+  <aside class="w-40 shrink-0">
+    <h2 class="text-xs font-semibold text-stone-600 mb-3">
+      テンプレート種別
+    </h2>
+    <div class="space-y-2 text-sm">
+      <% [["stationery", "便箋"], ["message_card", "メッセージカード"]].each do |kind, label| %>
+        <% active = (@kind == kind) %>
+        <%= link_to label,
+                    select_templates_path(kind: kind),
+                    class: [
+                      "block px-3 py-2 rounded-full border text-left",
+                      (active ? "bg-stone-900 text-white border-stone-900" : "border-stone-300 text-stone-700 hover:bg-stone-50")
+                    ].join(" ") %>
+      <% end %>
+    </div>
+    <div class="mt-6">
+      <%= link_to "トップに戻る",
+                  root_path,
+                  class: "text-xs text-stone-500 hover:underline" %>
+    </div>
+  </aside>
+
+  <!-- テンプレ一覧 -->
+  <main class="flex-1">
+    <div class="flex items-center justify-between mb-4">
+      <h1 class="text-sm font-semibold text-stone-800">
+        <%= @kind == "stationery" ? "便箋テンプレート" : "メッセージカードテンプレート" %>
+      </h1>
+      <p class="text-[11px] text-stone-500">
+        デザインを選んで「手紙作成」へ進みます
+      </p>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      <% @templates.each do |template| %>
+        <%= link_to new_letter_path(template_id: template.id), class: "block" do %>
+          <%= render "templates/card", template: template %>
+        <% end %>
+      <% end %>
+    </div>
+  </main>
+</div>

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -1,1 +1,66 @@
-<p>ここにデザインを表示していくよ</p>
+<section class="max-w-5xl mx-auto px-4 py-10">
+
+  <!-- キャッチコピー部分 -->
+  <div class="bg-stone-200 px-8 py-12 mb-10">
+    <div class="max-w-2xl mx-auto">
+      <p class="text-2xl md:text-3xl font-bold leading-relaxed text-stone-900 mb-6">
+        どんなアプリかイメージがつくようなメッセージや画像を<br class="hidden md:inline">
+        用意する。
+      </p>
+
+      <div class="flex justify-end">
+        <% if user_signed_in? %>
+          <%= link_to "手紙を書く",
+                      select_templates_path,
+                      class: "px-6 py-2.5 rounded-md bg-gray-600 text-white text-sm font-semibold shadow hover:bg-gray-700 active:scale-95 transition" %>
+        <% else %>
+          <%= link_to "新規登録してはじめる",
+                      new_user_registration_path,
+                      class: "px-6 py-2.5 rounded-md bg-gray-600 text-white text-sm font-semibold shadow hover:bg-gray-700 active:scale-95 transition" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <!-- デザイン一覧（便箋） -->
+  <div class="max-w-3xl mx-auto mb-8">
+    <h2 class="text-center text-sm font-semibold text-stone-800 mb-4">
+      便箋デザイン一覧
+    </h2>
+    <div class="flex justify-center gap-6">
+      <% @stationery_templates.each do |template| %>
+        <div class="w-24 md:w-28">
+          <% if user_signed_in? %>
+            <%= link_to select_templates_path(kind: "stationery"),
+                        class: "block" do %>
+              <%= render "templates/card", template: template %>
+            <% end %>
+          <% else %>
+            <%= render "templates/card", template: template %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- デザイン一覧（メッセージカード） -->
+  <div class="max-w-3xl mx-auto">
+    <h2 class="text-center text-sm font-semibold text-stone-800 mb-4">
+      メッセージカードデザイン一覧
+    </h2>
+    <div class="flex justify-center gap-6">
+      <% @message_card_templates.each do |template| %>
+        <div class="w-28 md:w-32">
+          <% if user_signed_in? %>
+            <%= link_to select_templates_path(kind: "message_card"),
+                        class: "block" do %>
+              <%= render "templates/card", template: template %>
+            <% end %>
+          <% else %>
+            <%= render "templates/card", template: template %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,18 @@ Rails.application.routes.draw do
   devise_scope :user do
     get '/users', to: redirect('/users/sign_up')
   end
-
+  #トップページ
   root 'top_pages#index'
+
+  # テンプレート一覧・デザイン選択用
+  resources :templates, only: [:index] do
+    #urlにidが必要ないためcollectionを使用
+    collection do
+      get :select   # /templates/select → デザイン選択ページ
+    end
+  end
+
+  resources :letters, only: [:new, :create, :show, :index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/seeds/templates.rb
+++ b/db/seeds/templates.rb
@@ -64,7 +64,7 @@ GREEN_LEAF_LAYOUT = {
 GRAY_NEUTRAL_LAYOUT = GREEN_LEAF_LAYOUT.merge(
   "background" => {
     "type" => "image",
-    "src"  => "templates/stationery/gray_neutral_12lines_full.png"
+    "src"  => "templates/stationery/gray_netural_12lines_full.png"
   }
 ).freeze
 
@@ -123,7 +123,7 @@ templates = [
     kind:           "stationery",
     title:          "Gray Neutral Letter",
     layout:         GRAY_NEUTRAL_LAYOUT,
-    thumbnail_path: "templates/stationery/gray_neutral_12lines_thumb.png",
+    thumbnail_path: "templates/stationery/gray_netural_12lines_thumb.png",
     active:         true
   },
   {


### PR DESCRIPTION
テンプレ一覧とテンプレ選択UI実装
・ルーティングの追加(templates/indexとletters関連-lettersの実装はissue9以降だが、newに飛ばすリンクだけ作成するため記述する)
・TemplateモデルにUIメソッド追加(ビュー側にサムネイルやkind(便箋/メッセージカードをもってこれるように）
・サムネイル表示に関するパーシャルを作成(templates/_card.html.erb　トップページとテンプレ選択UIに表示するサムネイルに関するもの)
・top_pages_controolerにテンプレ一覧を読み込む
・top_pages/index.html.erbの表示を整える(テンプレ選択→手紙作成ページへの遷移や、ログインの有無での遷移や表示を調整)
・templates_controllerの作成/テンプレ選択画面の作成

トップページのモーダル実装は今後行う。