### PR TITLE
ブラウザにtextareの実装と、UI微修正

### DIFF
--- a/app/views/letters/_preview_canvas.html.erb
+++ b/app/views/letters/_preview_canvas.html.erb
@@ -17,19 +17,43 @@
                     alt: @template.title %>
     <% end %>
 
-    <!-- 行ガイド（スケール適用済み） -->
+    <!-- 行ガイド ＋ textarea（スケール適用済み） -->
     <% placeholders.each do |ph| %>
       <% next unless ph["kind"] == "text" %>
 
+      <!-- ★ ここから追加：行IDと max_chars を取り出す -->
+      <% line_id   = ph["id"] %>
+      <% max_chars = ph.dig("constraints", "max_chars") %>
+      <!-- ★ ここまで追加 -->
+
+      <!-- ★ ここから変更：ガイド枠だけの div → textarea を内包する絶対配置コンテナに変更 -->
       <div
-        class="absolute border border-dashed border-sky-400/70 bg-transparent"
+        class="absolute"
         style="
           left:<%= ph["x_scaled"] %>px;
           top:<%= ph["y_scaled"] %>px;
           width:<%= ph["width_scaled"] %>px;
           height:<%= ph["height_scaled"] %>px;
-        ">
+        "
+      >
+        <%= text_area_tag(
+              "letter[placeholders][#{line_id}][value]",  # ★ name で line_id と紐づけ
+              nil,                                        # ★ 既存値は issue13 で対応
+              id: "letter_placeholders_#{line_id}_value",
+              rows: 1,
+              maxlength: max_chars,
+              class: "w-full h-full
+                      border-0 border-b
+                      bg-transparent
+                      text-base text-stone-900
+                      resize-none overflow-hidden
+                      focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-sky-400",
+              style: "box-sizing: border-box,
+                      border-bottom-color: #000000,
+                      padding: 0 4px;"
+            ) %>
       </div>
+      <!-- ★ ここまで変更 -->
     <% end %>
   </div>
 </div>

--- a/app/views/letters/new.html.erb
+++ b/app/views/letters/new.html.erb
@@ -1,10 +1,10 @@
 <section class="w-full px-6 py-8">
-  <div class=" max-w-7xl mr-auto ">
+  <div class="max-w-7xl mr-auto">
     <h1 class="text-2xl font-semibold text-stone-800 mb-6">
       手紙作成ページ
     </h1>
 
-    <div class="flex  gap-6 items-start ">
+    <div class="flex gap-6 items-start">
 
       <!-- 左サイドバー：テキスト設定（中身は後続issueで本実装） -->
       <aside class="flex-none w-64 bg-stone-100 border border-stone-200 rounded-md p-4 space-y-4">
@@ -30,44 +30,44 @@
         </div>
       </aside>
 
-      <!-- メインエリア -->
+      <!-- メインエリア：ここを form_with で丸ごとフォームにする -->
       <div class="flex-1 bg-white border border-stone-200 rounded-md p-6 space-y-6">
 
-        <!-- 選択中テンプレ＋デザイン変更 -->
-        <div class="flex gap-4 items-start">
-          <div class="<%= template_aspect_class(@template) %> w-40 overflow-hidden rounded-md bg-stone-200 flex items-center justify-center text-xs text-stone-600">
-          <% if @template&.display_image_path.present? %>
-            <%= image_tag @template.display_image_path,
-                          alt: @template.title,
-                          class: "w-full h-full object-cover" %>
-          <% else %>
-            選択したデザインが表示されます
-          <% end %>
-        </div>
-
-          <div class="flex-1">
-            <p class="text-sm text-stone-600 mb-1">
-              選択中の便箋（メッセージカード）／封筒デザイン
-            </p>
-            <p class="text-base font-semibold text-stone-800 mb-3">
-              <%= @template.title %>
-            </p>
-            <%= link_to "デザイン変更",
-                        select_templates_path(kind: @template.kind),
-                        class: "inline-flex items-center px-4 py-1.5 rounded-md border border-stone-300 text-sm text-stone-700 hover:bg-stone-50" %>
-          </div>
-        </div>
-
-        <!-- 入力/プレビュー枠 -->
-        <div class="mt-6">
-          <%= render "preview_canvas" %>
-        </div>
-
-        <!-- 手紙情報フォーム -->
         <%= form_with model: @letter, local: true do |f| %>
           <%= f.hidden_field :template_id, value: @template.id %>
 
-          <div class="space-y-4">
+          <!-- 選択中テンプレ＋デザイン変更 -->
+          <div class="flex gap-4 items-start">
+            <div class="<%= template_aspect_class(@template) %> w-40 overflow-hidden rounded-md bg-stone-200 flex items-center justify-center text-xs text-stone-600">
+              <% if @template&.display_image_path.present? %>
+                <%= image_tag @template.display_image_path,
+                              alt: @template.title,
+                              class: "w-full h-full object-cover" %>
+              <% else %>
+                選択したデザインが表示されます
+              <% end %>
+            </div>
+
+            <div class="flex-1">
+              <p class="text-sm text-stone-600 mb-1">
+                選択中の便箋（メッセージカード）／封筒デザイン
+              </p>
+              <p class="text-base font-semibold text-stone-800 mb-3">
+                <%= @template.title %>
+              </p>
+              <%= link_to "デザイン変更",
+                          select_templates_path(kind: @template.kind),
+                          class: "inline-flex items-center px-4 py-1.5 rounded-md border border-stone-300 text-sm text-stone-700 hover:bg-stone-50" %>
+            </div>
+          </div>
+
+          <!-- 入力/プレビュー枠（★ ここが textarea オーバーレイ付きプレビュー） -->
+          <div class="mt-6">
+            <%= render "preview_canvas" %>
+          </div>
+
+          <!-- 手紙情報フォーム -->
+          <div class="mt-6 space-y-4">
 
             <div>
               <%= f.label :recipient_name, "相手の名前", class: "block text-sm font-medium text-stone-800 mb-1" %>
@@ -96,13 +96,14 @@
               <% end %>
             </div>
 
-            <!-- ★ ここが submit ボタン -->
+            <!-- submit ボタン -->
             <div class="pt-4">
               <%= f.submit "作成完了",
                            class: "w-full inline-flex justify-center items-center px-4 py-2.5 rounded-md bg-rose-600 text-white text-sm font-semibold hover:bg-rose-700 active:scale-[0.99] transition" %>
             </div>
           </div>
-        <% end %>
+
+        <% end %> <!-- /form_with -->
 
       </div> <!-- /メインエリア -->
     </div>   <!-- /flex -->

--- a/db/seeds/templates.rb
+++ b/db/seeds/templates.rb
@@ -43,13 +43,13 @@ GREEN_LEAF_LAYOUT = {
         "height"      => 40,
 
         # デフォルトフォント。それぞれのテンプレートごとに自由に設定可能。
-        "font_family" => "Noto Serif JP",
-        "font_size"   => 24,
-        "color"       => "#333333",
+        "font_family" => "Noto Sans JP",
+        "font_size"   => 16,
+        "color"       => "#000000",
         "align"       => "left",
 
         # 最大文字数の制限。編集画面のフロント側で利用する想定。
-        "constraints" => { "max_chars" => 40 }
+        "constraints" => { "max_chars" => 52 }
       }
     end
   end
@@ -96,12 +96,12 @@ BEIGE_FLORAL_LAYOUT = {
         "width"       => 830,
         "height"      => 40,
 
-        "font_family" => "Noto Serif JP",
-        "font_size"   => 26,
-        "color"       => "#333333",
+        "font_family" => "Noto Sans JP",
+        "font_size"   => 16,
+        "color"       => "#000000",
         "align"       => "left",
 
-        "constraints" => { "max_chars" => 30 }
+        "constraints" => { "max_chars" => 42 }
       }
     end
   end


### PR DESCRIPTION
textareaの実装。(form_withメソッドの配下にパーシャルの読み込み部分を移動)
UIの微修正を実施。(ガイド線をなくし、下線のみとした。

当初は左側にプレビュー、右側にtextareaとしていたためJSの処理を実装する必要があったが、背景画像と重ねる方式に変更。

close #20 
close #21 