### PR TITLE
送信方法選択ページのUIとコピー機能(詳細ページも）の実装

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -44,6 +44,7 @@ class LettersController < ApplicationController
     
 
     if @letter.save
+      password_in_session(@letter)
       redirect_to share_letter_path(@letter), notice: "手紙を作成しました。共有情報を確認してください。"
     else
       # バリデーションエラー時は new を再表示
@@ -57,10 +58,11 @@ class LettersController < ApplicationController
   # 作成済みの手紙詳細（自分の手紙のみ）
   def show
     # set_letter で @letter は取得済み
+    @generated_view_password = session.dig(:generated_view_password_by_letter_id, @letter.id.to_s)
   end
 
   def share
-    @generated_view_password = session.dig(:generated_view_password_by_letter_id, @letter.id)
+    @generated_view_password = session.dig(:generated_view_password_by_letter_id, @letter.id.to_s)
   end
 
   private
@@ -85,10 +87,10 @@ class LettersController < ApplicationController
     )
   end
 
-  def password_in_session
+  def password_in_session(letter)
     return if letter.generated_view_password.blank?
 
-    session[:generated_view_password_by_letter_id ] ||= {}
-    session[:generated_view_password_by_letter_id ][letter.id] = letter.generated_view_password
+    session[:generated_view_password_by_letter_id] ||= {}
+    session[:generated_view_password_by_letter_id][letter.id.to_s] = letter.generated_view_password
   end
 end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,23 @@
+// Rails7で標準導入されている Stimulus から Controller クラスを読み込む
+import { Controller } from "@hotwired/stimulus"
+// Stimulus の Controller を継承したクラスを定義
+// data-action や event.currentTarget などが使えるようになる
+export default class extends Controller {
+  // コピー用の処理
+  // ボタンがクリックされたときに呼ばれる
+  copy(event) {
+    // クリックされたボタン要素そのものを取得(currentTarget→buttonを指定)
+    const button = event.currentTarget
+    // HTML の data-copy-text 属性に設定されたコピー対象の文字列を取得(dataset→HTML側のdata-copy-textをcopyTextへ変換)
+    const text = button.dataset.copyText
+    //コピー対象がない時は、以下の処理をスキップ
+    if (!text) return
+    // Clipboard API を使って文字列をコピーする
+    navigator.clipboard.writeText(text).then(() => {
+      // コピー成功後、ボタンの表示を「済み✔︎」に変更
+      button.textContent = "済み✔︎"
+      // 再クリックできないようにボタンを無効化
+      button.disabled = true
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,9 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
+import MessageController from "./message_controller"
+application.register("message", MessageController)

--- a/app/javascript/controllers/message_controller.js
+++ b/app/javascript/controllers/message_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["textarea", "button"]
+
+  copy(event) {
+    const button = event.currentTarget
+
+    const text = this.textareaTarget.value
+
+    if(!text) return
+
+    navigator.clipboard.writeText(text).then(() => {
+      button.textContent = "済み✔︎"
+      button.disabled = true
+    })
+  }
+}

--- a/app/views/letters/new.html.erb
+++ b/app/views/letters/new.html.erb
@@ -84,7 +84,7 @@
             <!-- パスワード発行のチェックボックス -->
             <div class="mt-4">
               <%= f.label :enable_password, class: "flex items-start gap-2 text-sm text-stone-800 cursor-pointer" do %>
-                <%= f.check_box :enable_password, class: "mt-1" %>
+                <%= f.check_box :enable_password, { class: "mt-1" }, "1", "0" %>
                 <span>
                   閲覧時にパスワードを要求する
                   <span class="block text-xs text-stone-500">

--- a/app/views/letters/share.html.erb
+++ b/app/views/letters/share.html.erb
@@ -1,1 +1,136 @@
-<h>issue16で実装だよ</h>
+<section class="max-w-5xl mx-auto px-4 py-10">
+  <header class="mx-auto w-full max-w-xl mb-6 text-center">
+    <p class="text-2xl font-bold text-stone-700">
+      手紙作成完了
+    </p>
+
+    <h1 class="text-xl font-semibold text-stone-500 pt-6 ">
+      作成した手紙を贈りましょう！
+    </h1>
+
+    <p class="mt-2 text-xs text-stone-500 pt-6">
+      カード公開日（作成日）：
+      <%= @letter.created_at.strftime("%Y年%m月%d日") %>
+      <%# ／ 閲覧回数：◯回（最終閲覧：yyyy/mm/dd hh:mm） ※後で Accesses から集計 %>
+    </p>
+  </header>
+
+  <!-- 情報（URL/パスワード/お届け用メッセージ) -->
+  <div class="mx-auto w-full max-w-xl mt-8">
+    <div
+      class="rounded-lg border border-stone-200 bg-stone-50 px-4 py-4 space-y-5"
+      data-controller="clipboard"
+    >
+      <!-- ▼ 閲覧URL -->
+      <div>
+        <p class="text-xs font-medium text-stone-500 mb-1">
+          閲覧URL
+        </p>
+        <div class="flex items-center gap-2">
+          <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
+            <%= public_letter_url(@letter.view_token) %>
+          </p>
+          <button
+            type="button"
+            class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                   bg-stone-800 text-white hover:bg-stone-700"
+            data-action="click->clipboard#copy"
+            data-copy-text="<%= public_letter_url(@letter.view_token) %>"
+          >
+            コピー
+          </button>
+        </div>
+      </div>
+
+      <!-- ▼ 閲覧パスワード（パスワード要求 ON のときだけ表示） -->
+      <% if @letter.enable_password? %>
+        <div>
+          <p class="text-xs font-medium text-stone-500 mb-1">
+            閲覧パスワード
+          </p>
+
+          <% if @generated_view_password.present? %>
+            <div class="flex items-center gap-2">
+              <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
+                <%= @generated_view_password %>
+              </p>
+              <button
+                type="button"
+                class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                      bg-stone-800 text-white hover:bg-stone-700"
+                data-action="click->clipboard#copy"
+                data-copy-text="<%= @generated_view_password %>"
+              >
+                コピー
+              </button>
+            </div>
+          <% else %>
+            <div class="flex items-center gap-2">
+              <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-2">
+                ※ セキュリティのため、パスワードは再表示できません。<br>
+                手紙を作成直後のみ確認できます。
+              </p>
+              <button
+                type="button"
+                class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                      bg-stone-200 text-stone-400 cursor-not-allowed"
+                disabled
+                aria-disabled="true"
+              >
+                コピー
+              </button>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <!-- ▼ お届け用メッセージ（message controller はこのブロックに付ける） -->
+      <div data-controller="message">
+        <p class="text-xs font-medium text-stone-500 mb-1">
+          お届け用メッセージ
+        </p>
+
+        <div class="flex items-start gap-2">
+          <textarea
+            class="flex-1 min-h-[260px] bg-white border border-stone-200 rounded-md px-3 py-2 text-sm
+                   focus:outline-none focus:border-stone-300"
+            data-message-target="textarea"
+          >Letteoで手紙が届きました！
+<%= @letter.sender_name %>さんからの手紙を見てみましょう！
+
+【閲覧URL】
+<%= public_letter_url(@letter.view_token) %>
+<% if @letter.enable_password? %>
+
+【閲覧パスワード】
+<%= @generated_view_password %>
+<% end %></textarea>
+
+          <button
+            type="button"
+            class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                   bg-stone-800 text-white hover:bg-stone-700"
+            data-action="click->message#copy"
+            data-message-target="button"
+          >
+            コピー
+          </button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- 戻るボタンなど -->
+  <div class="mx-auto w-full max-w-xl mt-6 flex justify-between">
+    <%= link_to "贈った手紙一覧に戻る",
+                letters_path,
+                class: "text-sm text-stone-600 hover:text-stone-900" %>
+  </div>
+
+  <div class="mx-auto w-full max-w-xl mt-6 flex justify-between">
+    <%= link_to "TOPへ",
+                root_path,
+                class: "text-sm text-stone-600 hover:text-stone-900" %>
+  </div>
+</section>

--- a/app/views/letters/show.html.erb
+++ b/app/views/letters/show.html.erb
@@ -45,15 +45,14 @@
         </p>
         <div class="flex items-center gap-2">
           <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
-            <%# 本番では view_token ではなく実際の URL を組み立てる想定 %>
-            <%= @letter.view_token %>
+            <%= public_letter_url(@letter.view_token) %>
           </p>
           <button
             type="button"
             class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
                    bg-stone-800 text-white hover:bg-stone-700"
             data-action="click->clipboard#copy"
-            data-copy-text="<%= @letter.view_token %>"
+            data-copy-text="<%= public_letter_url(@letter.view_token) %>"
           >
             コピー
           </button>
@@ -66,25 +65,40 @@
           <p class="text-xs font-medium text-stone-500 mb-1">
             閲覧パスワード
           </p>
-          <div class="flex items-center gap-2">
-            <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
-              <%= @letter.view_password_digest.presence || "パスワード未設定" %>
-            </p>
-            <button
-              type="button"
-              class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
-                    bg-stone-800 text-white hover:bg-stone-700"
-              data-action="click->clipboard#copy"
-              data-copy-text="<%= @letter.view_password_digest.to_s %>"
-            >
-              コピー
-            </button>
-          </div>
+          <% if @generated_view_password.present? %>
+            <div class="flex items-center gap-2">
+              <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
+                <%= @generated_view_password  %>
+              </p>
+              <button
+                type="button"
+                class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                      bg-stone-800 text-white hover:bg-stone-700"
+                data-action="click->clipboard#copy"
+                data-copy-text="<%= @generated_view_password %>"
+              >
+                コピー
+              </button>
+            </div>
+          <% else %>
+            <div class="flex items-center gap-2">
+              <p class="flex-1 text-sm text-stone-800 break-all bg-white rounded border border-stone-200 px-2 py-1">
+                ※ セキュリティのため、パスワードは再表示できません。<br>
+                手紙を作成直後のみ確認できます。
+              </p>
+              <button
+                type="button"
+                class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
+                      bg-stone-200 text-stone-400 cursor-not-allowed"
+                disabled
+                aria-disabled="true"
+              >
+                コピー
+              </button>
+            </div>
+          <% end %>
         </div>
       <% end %>
-
-      <!-- コピー結果メッセージ -->
-      <p class="text-[11px] text-stone-500 h-4" data-clipboard-target="feedback"></p>
     </div>
   </div>
 


### PR DESCRIPTION
1. letters_controller.rbのshowアクションにsessionを追加。
2. letters/show.html.erbの修正
3. JSのcontrollerファイル生成。
4. clipboard_controller.jsの実装
5. index.jsにcode追加。
6. 送信方法選択ページのUIも整える。(share.html.erb)
7. textareaをコピーする機能を実装(message_controller.js)
8. 忘れずindex.jsに追加
9. 作成直後なのに閲覧パスワードが表示されたなかったので、原因特定した。letters_controller.rbを一部修正

close #25 