### PR TITLE
閲覧ページのパスワード認証機能を実装

### DIFF
--- a/app/controllers/accesses_controller.rb
+++ b/app/controllers/accesses_controller.rb
@@ -2,9 +2,49 @@ class AccessesController < ApplicationController
   def show
     @letter = Letter.find_by!(view_token: params[:token])
     @template = @letter.template
+    #view側で使う（パスワードが必要かどうか）
+    @password_required = @letter.enable_password?
+    #view側で使う（このブラウザがこのtokenを認証済みか）
+    @authorized = authorized_for?(@letter)
+    
+  end
+
+  def verify
+    @letter = Letter.find_by!(view_token: params[:token])
+
+    # パスワード不要の手紙なら即OK扱いでshowへ
+    unless @letter.enable_password?
+      authorize!(@letter)
+      #これ以下の処理を実行しないようにするためreturnを使用
+      return redirect_to public_letter_path(@letter.view_token)
+    end
+    #view側から取得したパシワードを格納(空でも""になるように.to_sで文字列化)
+    input = params[:view_password].to_s
+    #letterモデルでhas_secure_passwordを定義することで、使用することができるメソッド。
+    if @letter.authenticate_view_password(input)
+      #sessionに値を保持
+      authorize!(@letter)
+      #verifyは処理専用で、表示はshowに集約する設計なので、成功/失敗どちらもshowへredirectする（差分はflashとセッション状態）
+      redirect_to public_letter_path(@letter.view_token), notice: "認証しました"
+    else
+      redirect_to public_letter_path(@letter.view_token), alert: "パスワードが違います"
+    end
   end
 
   def public_page?
     true
+  end
+
+
+  private
+  #認証済みかどうかチェックするメソッド（セッションにこのtokenが入っていれば“このブラウザは認証済み”とみなす）
+  def authorized_for?(letter)
+    (session[:authorized_letter_tokens] || []).include?(letter.view_token)
+  end
+  #認証済みtokenをsessionに保持
+  def authorize!(letter)
+    session[:authorized_letter_tokens] ||= []
+    session[:authorized_letter_tokens] << letter.view_token
+    session[:authorized_letter_tokens].uniq!
   end
 end

--- a/app/views/accesses/show.html.erb
+++ b/app/views/accesses/show.html.erb
@@ -1,3 +1,5 @@
+<% can_open = !@password_required || @authorized %>
+
 <div
   data-controller="lottie-envelope"
   data-lottie-envelope-path-value="/lotties/envelope_open.json"
@@ -5,7 +7,7 @@
 >
   <div class="mb-6 text-center">
     <p class = "text-xl sm:text-2xl font-semibold text-stone-700">
-      手紙が届きました！
+      <%= @letter.sender_name %>さんから手紙が届きました！
     </p>
     <p class="mt-1 text-sm text-stone-500">
       封筒を開いてください
@@ -15,11 +17,29 @@
     data-lottie-envelope-target="container"
     class="w-[320px] aspect-square overflow-hidden"
   ></div>
+  <% if @password_required && !@authorized %>
+    <div class="mt-6 w-full max-w-sm bg-white rounded-xl border border-stone-200 p-4">
+      <p class="text-sm font-semibold text-stone-700">
+        この手紙にはパスワードが設定されています
+      </p>
+      <p class="mt-1 text-xs text-stone-500">
+        閲覧するにはパスワードの入力が必要です。
+      </p>
 
+      <%= form_with url: verify_public_letter_path(@letter.view_token), method: :post, class: "mt-3 space-y-3" do %>
+        <%= password_field_tag :view_password, nil,
+        class: "w-full h-11 rounded-lg border-stone-300 focus:border-stone-500 focus:ring-stone-500 border border-gray-300",
+            placeholder: " パスワード" %>
+        <%= submit_tag "認証する",
+            class: "w-full h-11 rounded-lg bg-stone-700 text-white hover:bg-stone-800 " %>
+      <% end %>
+    </div>
+  <% end %>
   <button
     data-lottie-envelope-target="button"
     data-action="click->lottie-envelope#open"
-    class="absolute bottom-0 mt-6 h-12 px-10 rounded-full bg-stone-700 text-white"
+    class="absolute bottom-0 mt-6 h-12 px-10 rounded-full bg-stone-700 text-white <%= can_open ? '' : 'hidden' %>"
+    <%= can_open ? '' : 'disabled' %>
   >
     封筒を開く
   </button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,10 +12,10 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <p class="text-green-600 text-center"><%= notice %></p>
-    <p class="text-red-600 text-center"><%= alert %></p>
     <%= render 'shared/header'%>
     <main class="flex-grow pt-20 pb-16">
+      <p class="text-green-600 text-center"><%= notice %></p>
+      <p class="text-red-600 text-center"><%= alert %></p>
       <%= yield %>
     </main>
     <%= render 'shared/footer'%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
 <header class="bg-gray-100 shadow p-4 fixed top-0 w-full z-10">
-  <div class="container mx-auto flex justify-between items-center h-full">
-    <h1 class="text-2xl font-bold text-gray-900"><%= link_to "Letteo", root_path %></h1>
+  <div class="container mx-auto flex items-center h-full <%= public_page? ? 'justify-center' : 'justify-between'%>">
     <%# 公開ページはボタン非表示%>
     <% if public_page? %>
-
+      <h1 class=" text-2xl font-bold text-gray-900"><%= link_to "Letteo", root_path %></h1>
     <%# ログイン中の場合：ログアウトボタンのみ表示%>
     <% elsif user_signed_in? %>
+      <h1 class="text-2xl font-bold text-gray-900"><%= link_to "Letteo", root_path %></h1>
       <nav class= "flex space-x-4 mr-14">
         <%= link_to "贈った手紙一覧",
           letters_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'letters/index'
-  get 'letters/show'
-  get 'letters/new'
-  get 'letters/create'
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations'
@@ -31,6 +27,8 @@ Rails.application.routes.draw do
 
   #公開URL
   get "/l/:token", to: "accesses#show", as: :public_letter
+  #閲覧パスワードの認証処理
+  post "/l/:token/verify", to: "accesses#verify", as: :verify_public_letter
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
1.ルーティングの追加
・閲覧パスワードの認証処理用
2.コントローラーへ認証ロジック追加
3.show.html.erbに条件分岐を追加（認証され、sessionに値が保持されている場合に封筒を開けるボタン出現）
4.ヘッダーについて、閲覧ページの時のみ、ロゴを画面中央に配置
5.application,html.erbのnoticeとalertの位置がヘッダーに被っていたので修正。

close #28 