### PR TITLE
MVPリリース前のUI微調整完了

### DIFF
--- a/app/views/accesses/show.html.erb
+++ b/app/views/accesses/show.html.erb
@@ -31,7 +31,7 @@
         class: "w-full h-11 rounded-lg border-stone-300 focus:border-stone-500 focus:ring-stone-500 border border-gray-300",
             placeholder: " パスワード" %>
         <%= submit_tag "認証する",
-            class: "w-full h-11 rounded-lg bg-stone-700 text-white hover:bg-stone-800 " %>
+            class: "w-full h-11 rounded-lg bg-gray-700 text-white hover:bg-gray-800 " %>
       <% end %>
     </div>
   <% end %>
@@ -57,11 +57,18 @@
       class="absolute inset-0 bg-black/40"
       data-action="click->lottie-envelope#close"
     ></div>
-
+    
+    <% modal_size_class =
+      if @template.kind == "stationery"
+        "max-w-xl max-h-[92vh]"
+      else
+        "max-w-lg max-h-[80vh]"
+      end 
+    %>
     <!-- カード本体 -->
     <div
       data-lottie-envelope-target="modalCard"
-      class="relative w-full max-w-lg max-h-[80vh]
+      class="relative <% modal_size_class %>
             bg-white rounded-2xl shadow-xl
             overflow-hidden
             transform scale-95 opacity-0
@@ -69,7 +76,7 @@
     >
       <!-- ヘッダー -->
       <div class="flex items-center justify-between px-4 py-3 border-b border-stone-200">
-        <p class="text-sm font-semibold text-stone-700"><%= @template.kind %></p>
+        <p class="text-sm font-semibold text-stone-700"><%= @template.kind_label %></p>
         <button
           type="button"
           class="text-sm text-stone-500 hover:text-stone-700"

--- a/app/views/letters/_preview_canvas.html.erb
+++ b/app/views/letters/_preview_canvas.html.erb
@@ -5,7 +5,7 @@
 <% background     = data[:background] %>
 <% placeholders   = data[:placeholders_scaled] %>
 
-<div class="inline-flex border-2 border-sky-400 bg-stone-50 rounded-md p-4 overflow-auto">
+<div class="inline-flex border-2 border-gray-200 bg-stone-50 rounded-md p-4 overflow-auto">
   <div
     class="relative rounded-md overflow-hidden bg-stone-100"
     style="width:<%= display_width %>px; height:<%= display_height %>px;"

--- a/app/views/letters/_show_preview_canvas.html.erb
+++ b/app/views/letters/_show_preview_canvas.html.erb
@@ -6,7 +6,7 @@
 <% placeholders      = data[:placeholders_scaled] %>
 <% body_placeholders = @letter.body["placeholders"] || {} %>
 
-<div class="inline-flex border-2 border-sky-400 bg-stone-50 rounded-md p-4 overflow-auto">
+<div class="inline-flex border-2 border-gray-200 bg-stone-50 rounded-md p-4 overflow-auto">
   <div
     class="relative rounded-md overflow-hidden bg-stone-100"
     style="width:<%= display_width %>px; height:<%= display_height %>px;"

--- a/app/views/letters/new.html.erb
+++ b/app/views/letters/new.html.erb
@@ -11,21 +11,21 @@
         <div>
           <label class="block text-sm font-medium text-stone-700 mb-1">Text font</label>
           <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>標準フォント</option>
+            <option>Noto Sans JP(標準)</option>
           </select>
         </div>
 
         <div>
           <label class="block text-sm font-medium text-stone-700 mb-1">Text size</label>
           <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>標準サイズ</option>
+            <option>16px(標準)</option>
           </select>
         </div>
 
         <div>
           <label class="block text-sm font-medium text-stone-700 mb-1">Text color</label>
           <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>標準カラー</option>
+            <option>黒(標準)</option>
           </select>
         </div>
       </aside>
@@ -48,7 +48,7 @@
             </div>
             <div class="flex-1">
               <p class="text-sm text-stone-600 mb-1">
-                選択中の便箋（メッセージカード）／封筒デザイン
+                選択中の便箋（メッセージカード）
               </p>
               <p class="text-base font-semibold text-stone-800 mb-3">
                 <%= @template.title %>
@@ -70,14 +70,14 @@
             <div>
               <%= f.label :recipient_name, "相手の名前", class: "block text-sm font-medium text-stone-800 mb-1" %>
               <%= f.text_field :recipient_name,
-                               class: "w-full border border-stone-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400",
+                               class: "w-full border border-stone-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-gray-400",
                                placeholder: "山田 太郎 さん など" %>
             </div>
 
             <div>
               <%= f.label :sender_name, "あなたの名前", class: "block text-sm font-medium text-stone-800 mb-1" %>
               <%= f.text_field :sender_name,
-                               class: "w-full border border-stone-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400",
+                               class: "w-full border border-stone-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-gray-400",
                                placeholder: "あなたの名前" %>
             </div>
 
@@ -97,7 +97,7 @@
             <!-- submit ボタン -->
             <div class="pt-4">
               <%= f.submit "作成完了",
-                           class: "w-full inline-flex justify-center items-center px-4 py-2.5 rounded-md bg-rose-600 text-white text-sm font-semibold hover:bg-rose-700 active:scale-[0.99] transition" %>
+                           class: "w-full inline-flex justify-center items-center px-4 py-2.5 rounded-md bg-gray-700 text-white text-sm font-semibold hover:bg-gray-800 active:scale-[0.99] transition" %>
             </div>
           </div>
 

--- a/app/views/letters/share.html.erb
+++ b/app/views/letters/share.html.erb
@@ -33,7 +33,7 @@
           <button
             type="button"
             class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
-                   bg-stone-800 text-white hover:bg-stone-700"
+                   bg-gray-700 text-white hover:bg-gray-800"
             data-action="click->clipboard#copy"
             data-copy-text="<%= public_letter_url(@letter.view_token) %>"
           >
@@ -57,7 +57,7 @@
               <button
                 type="button"
                 class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
-                      bg-stone-800 text-white hover:bg-stone-700"
+                      bg-gray-700 text-white hover:bg-gray-800"
                 data-action="click->clipboard#copy"
                 data-copy-text="<%= @generated_view_password %>"
               >
@@ -109,7 +109,7 @@
           <button
             type="button"
             class="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium
-                   bg-stone-800 text-white hover:bg-stone-700"
+                   bg-gray-700 text-white hover:bg-gray-800"
             data-action="click->message#copy"
             data-message-target="button"
           >

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,23 +9,23 @@
       <nav class= "flex space-x-4 mr-14">
         <%= link_to "贈った手紙一覧",
           letters_path,
-          class: "rounded-md bg-gray-800 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300"
+          class: "text-sm font-semibold rounded-md bg-gray-700 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300"
         %>
         <%= link_to "ログアウト",
           destroy_user_session_path,
           data: { turbo_method: :delete},
-          class: "rounded-md bg-gray-800 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300"
+          class: "text-sm font-semibold rounded-md bg-gray-700 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300"
         %>
       </nav >
 
     <% else %>
-
+      <h1 class="text-2xl font-bold text-gray-900"><%= link_to "Letteo", root_path %></h1>
       <%# 未ログイン状態：ログイン/新規登録ページでは非表示 %>
       <% unless (controller_name == "sessions" && action_name == "new") || (controller_name == "registrations" && action_name == "new") %>
 
         <nav class="flex space-x-4">
-          <%= link_to "ログイン", new_user_session_path, class: "rounded-md bg-gray-800 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300" %>
-          <%= link_to "新規登録", new_user_registration_path, class: "rounded-md bg-gray-800 px-4 py-2 text-white shadow   hover:bg-gray-700 active:scale-95 transition-all duration-300 mr-14" %>
+          <%= link_to "ログイン", new_user_session_path, class: "text-sm font-semibold rounded-md bg-gray-700 px-4 py-2 text-white shadow hover:bg-gray-700 active:scale-95 transition-all duration-300" %>
+          <%= link_to "新規登録", new_user_registration_path, class: "text-sm font-semibold rounded-md bg-gray-700 px-4 py-2 text-white shadow   hover:bg-gray-700 active:scale-95 transition-all duration-300 mr-14" %>
         </nav>
       <% end %>
     <% end %>

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -3,20 +3,24 @@
   <!-- キャッチコピー部分 -->
   <div class="bg-stone-200 px-8 py-12 mb-10">
     <div class="max-w-2xl mx-auto">
-      <p class="text-2xl md:text-3xl font-bold leading-relaxed text-stone-900 mb-6">
-        どんなアプリかイメージがつくようなメッセージや画像を<br class="hidden md:inline">
-        用意する。
+      <p class="mb-6">
+        <span class="block text-2xl md:text-3xl font-bold leading-snug text-stone-900">
+        気持ちに、ひと工夫
+        </span>
+        <span class="block mt-2 text-base md:text-lg font-bold text-stone-500">
+        演出付きで贈れる、デジタル手紙。
+        </span>
       </p>
 
       <div class="flex justify-end">
         <% if user_signed_in? %>
           <%= link_to "手紙を書く",
                       select_templates_path,
-                      class: "px-6 py-2.5 rounded-md bg-gray-600 text-white text-sm font-semibold shadow hover:bg-gray-700 active:scale-95 transition" %>
+                      class: "px-6 py-2.5 rounded-md bg-gray-700 text-white text-sm font-semibold shadow hover:bg-gray-800 active:scale-95 transition" %>
         <% else %>
           <%= link_to "新規登録してはじめる",
                       new_user_registration_path,
-                      class: "px-6 py-2.5 rounded-md bg-gray-600 text-white text-sm font-semibold shadow hover:bg-gray-700 active:scale-95 transition" %>
+                      class: "px-6 py-2.5 rounded-md bg-gray-700 text-white text-sm font-semibold shadow hover:bg-gray-800 active:scale-95 transition" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
01_ヘッダーの修正
- ログアウト中のロゴの位置
- ログイン/ログアウトなどの配色をトップページとあわせる。(bg-gray-700)
- 文字のフォントやサイズ、太さをトップページとあわせる。(text-sm font-semibold)
02_トップページの修正
- キャッチコピーの追加
- ボタンの配色をヘッダーと合わせる。(bg-gray-700 hoberは800へ)
- 文字のフォントやサイズ、太さをヘッダーと合わせる。(text-sm font-semibold)
03_手紙作成ページの修正
- フォントやサイズの標準設定をプルダウンに表示（今後選べるように実装）
- 作成完了ボタンの配色を変更。(bg-gray-700)
- render先(*preview*canvas.erb)の修正。(青枠をborder-gray-200へ）
- 入力フォームのフォーカス時の色を修正(grayへ)
04_閲覧URL/Passページの修正
コピーボタンをgrayへ統一
05_閲覧ページの修正
- 認証ボタンをgrayへ
- モーダルのサイズを便箋/メッセージカードで適切なサイズへ条件分岐
close #61 