### PR TITLE
モーダルの表示内容精査完了

### DIFF
--- a/app/javascript/controllers/template_modal_controller.js
+++ b/app/javascript/controllers/template_modal_controller.js
@@ -1,15 +1,32 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["modal"]
-
+  static targets = ["modal", "preview", "kind", "title", "category", "createLink"]
+  
   connect() {
     // ESC用ハンドラを this に束縛して保存（後で remove できるように）
     this._onKeydown = this.onKeydown.bind(this)
   }
 
   open(event) {
+    const el = event.currentTarget
+    const {
+      templateId,
+      templateKind,
+      templateTitle,
+      templateCategory,
+      templateThumbnail
+    } = el.dataset
 
+    //モーダルに表示
+    this.previewTarget.src = templateThumbnail
+    this.kindTarget.textContent = templateKind
+    this.titleTarget.textContent = templateTitle
+    this.categoryTarget.textContent = templateCategory || ""
+
+    this.createLinkTarget.href = `/letters/new?template_id=${templateId}`
+
+    //モーダル自体のopem処理
     this.modalTarget.classList.remove("hidden")
     document.addEventListener("keydown", this._onKeydown)
   }

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -37,7 +37,14 @@
           <% if user_signed_in? %>
             <%= button_tag type:"button",
                             class: "block w-full text-left",
-                            data: { action: "click->template-modal#open"} do %>
+                            data: {
+                              action: "click->template-modal#open",
+                              template_id: template.id,
+                              template_kind: template.kind,
+                              template_title: template.title,
+                              template_category: template.category,
+                              template_thumbnail: asset_path(template.thumbnail_path)
+                            } do %>
               <%= render "templates/card", template: template %>
             <% end %>
           <% else %>
@@ -59,7 +66,14 @@
           <% if user_signed_in? %>
             <%= button_tag type: "button",
                             class: "block w-full text-left",
-                            data: { action: "click->template-modal#open" } do %>
+                            data: {
+                              action: "click->template-modal#open",
+                              template_id: template.id,
+                              template_kind: template.kind,
+                              template_title: template.title,
+                              template_category: template.category,
+                              template_thumbnail: asset_path(template.thumbnail_path)
+                            } do %>
               <%= render "templates/card", template: template %>
             <% end %>
           <% else %>
@@ -90,20 +104,42 @@
       </div>
 
       <div class="px-4 py-4">
-        <p class="text-sm text-stone-600"></p>
+        <div class="flex gap-4">
+          <img 
+            data-template-modal-target="preview"
+            class="w-40 md:w-44 h-auto rounded border border-stone-300 "
+          >
+          <div class="text-sm text-stone-700 space-y-3">
+            <div>
+              <p class="text-xs text-stone-500">kind</p>
+              <p data-template-modal-target="kind" class="font-semibold"></p>
+            </div>
 
+            <div>
+              <p class="text-xs text-tone-500">title</p>
+              <p data-template-modal-target="title" class="font-semibold"></p>
+            </div>
+
+            <div>
+              <p class="text-xs text-tone-500">category</p>
+              <p data-template-modal-target="category" class="font-semibold"></p>
+            </div>
+          </div>
+        </div>
         <div class="mt-4 flex justify-end gap-2">
           <button type="button"
                 class="px-4 py-2 rounded-md bg-stone-100 text-stone-700 text-stone-700 font-semibold hover:bg-stone-200"
                 data-action="click->template-modal#close">
           閉じる
           </button>
-          
-          <button type="button"
+          <!-- buttonではなくa hrefに修正  -->
+          <a
+            data-template-modal-target="createLink"
                   class="px-4 py-2 rounded-md bg-gray-700 text-white text-sm font-semibold hover:bg-gray-800"
-                  >
+                  href="#"
+          >
             このデザインで作成
-          </button>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
実装手順
- クリックしたテンプレ情報をStimulusに渡す（data属性)
- モーダルないの表示(img/kind/title/category)を差し替える。
- 「このデザインで作成」リンクの作成。（初期状態を<a href>="#”</a>とし、stimulusで取得したtemplateidを"#"この部分を`/letters/new?template_id=${templateId}`に差し替えることで、任意のテンプレ作成画面へ遷移できるようになる。

