### PR TITLE
文字スタイル変更機能追加（今後微修正必要）

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("lottie-envelope", LottieEnvelopeController)
 
 import TemplateModalController from "./template_modal_controller"
 application.register("template-modal", TemplateModalController)
+
+import TextStyleController from "./text_style_controller"
+application.register("text-style", TextStyleController)

--- a/app/javascript/controllers/text_style_controller.js
+++ b/app/javascript/controllers/text_style_controller.js
@@ -1,0 +1,133 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * 役割：
+ * - textarea をクリックしたら「選択中の行」を覚える
+ * - パネル操作で、選択中の行だけ style を反映する
+ * - submit 用 hidden fields に overrides を保存する
+ */
+export default class extends Controller {
+  static targets = [
+    "line",
+    "panel", "help",
+    "fontFamily", "fontSize", "color",
+    "hiddenFontFamily", "hiddenFontSize", "hiddenColor"
+  ]
+
+  connect() {
+    this.selectedLineId = null
+    this._setPanelEnabled(false)
+  }
+
+  // textarea をクリック/フォーカスしたとき
+  select(event) {
+    const el = event.currentTarget
+    const lineId = el.dataset.lineId
+    this.selectedLineId = lineId
+
+    // ① 選択中の行を見た目で分かるようにする
+    this.lineTargets.forEach(t => t.classList.remove("ring-2", "ring-stone-500", "bg-stone-50"))
+    el.classList.add("ring-2", "ring-stone-500", "bg-stone-50")
+
+    // ② パネルを有効化
+    this._setPanelEnabled(true)
+
+    // ③ パネルに「現在値」を表示（hidden があれば overrides、なければ default）
+    const current = this._currentStyleFor(lineId)
+    this.fontFamilyTarget.value = current.font_family
+    this.fontSizeTarget.value = String(current.font_size)
+    this.colorTarget.value = current.color
+  }
+
+  // パネル操作（フォント/サイズ/色）で呼ばれる
+  apply() {
+    if (!this.selectedLineId) return
+
+    const line = this._findLine(this.selectedLineId)
+    if (!line) return
+
+    const font_family = this.fontFamilyTarget.value
+    const font_size = parseInt(this.fontSizeTarget.value, 10)
+    const color = this.colorTarget.value
+
+    // ① textarea に即時反映
+    line.style.fontFamily = font_family
+    line.style.fontSize = `${font_size}px`
+    line.style.color = color
+
+    // ② hidden に保存（submit で params に載る）
+    this._setHidden(this.selectedLineId, { font_family, font_size, color })
+  }
+
+  // 「デフォルトに戻す」ボタン
+  reset() {
+    if (!this.selectedLineId) return
+
+    const line = this._findLine(this.selectedLineId)
+    if (!line) return
+
+    const d = this._defaultsFor(this.selectedLineId)
+
+    // textarea をデフォルトに戻す
+    line.style.fontFamily = d.font_family
+    line.style.fontSize = `${d.font_size}px`
+    line.style.color = d.color
+
+    // hidden を空に（→ サーバ側で nil にする）
+    this._setHidden(this.selectedLineId, { font_family: "", font_size: "", color: "" })
+
+    // パネル表示もデフォルトに戻す
+    this.fontFamilyTarget.value = d.font_family
+    this.fontSizeTarget.value = String(d.font_size)
+    this.colorTarget.value = d.color
+  }
+
+  // ---- private helpers ----
+
+  _setPanelEnabled(enabled) {
+    // ✅ disabled 属性は送信されなくなるので使わない
+    if (enabled) {
+      this.panelTarget.classList.remove("opacity-50", "pointer-events-none")
+    } else {
+      this.panelTarget.classList.add("opacity-50", "pointer-events-none")
+    }
+  }
+
+  _findLine(lineId) {
+    return this.lineTargets.find(t => t.dataset.lineId === lineId)
+  }
+
+  _defaultsFor(lineId) {
+    const line = this._findLine(lineId)
+    return {
+      font_family: line?.dataset.defaultFontFamily || "Noto Sans JP",
+      font_size: parseInt(line?.dataset.defaultFontSize || "16", 10),
+      color: line?.dataset.defaultColor || "#000000"
+    }
+  }
+
+  _currentStyleFor(lineId) {
+    // hidden が埋まっていれば overrides とみなす（空なら default）
+    const d = this._defaultsFor(lineId)
+
+    const hf = this.hiddenFontFamilyTargets.find(t => t.dataset.lineId === lineId)?.value
+    const hs = this.hiddenFontSizeTargets.find(t => t.dataset.lineId === lineId)?.value
+    const hc = this.hiddenColorTargets.find(t => t.dataset.lineId === lineId)?.value
+
+    return {
+      font_family: hf || d.font_family,
+      font_size: hs ? parseInt(hs, 10) : d.font_size,
+      color: hc || d.color
+    }
+  }
+
+  _setHidden(lineId, { font_family, font_size, color }) {
+    const hf = this.hiddenFontFamilyTargets.find(t => t.dataset.lineId === lineId)
+    const hs = this.hiddenFontSizeTargets.find(t => t.dataset.lineId === lineId)
+    const hc = this.hiddenColorTargets.find(t => t.dataset.lineId === lineId)
+
+    if (hf) hf.value = font_family
+    if (hs) hs.value = font_size === "" ? "" : String(font_size)
+    if (hc) hc.value = color
+  }
+}

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -38,10 +38,24 @@ class Letter < ApplicationRecord
     placeholders.each do |line_id, attrs|
       #そこからvalueを変数に定義
       value = attrs["value"].to_s
+
+      raw = attrs["overrides"].is_a?(Hash) ? attrs["overrides"] : {}
       
+      overrides = {
+        "font_family" => raw["font_family"].to_s,
+        "font_size" => raw["font_size"].to_s,
+        "color" => raw["color"].to_s
+      }
+
+      overrides.delete_if { |_k, v| v.blank? }
+      overrides = nil if overrides.blank?
+
+
+
+
       body_hash["placeholders"][line_id] ||= {}
       body_hash["placeholders"][line_id]["value"] = value
-      body_hash["placeholders"][line_id]["overrides"] ||= nil
+      body_hash["placeholders"][line_id]["overrides"] = overrides
     end
     
     body_hash["background"] ||= nil

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <!-- ✅ Google Fonts（Noto Sans JP + Noto Serif JP） -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet">
+    
+
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 
     <%# stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/letters/_preview_canvas.html.erb
+++ b/app/views/letters/_preview_canvas.html.erb
@@ -21,10 +21,8 @@
     <% placeholders.each do |ph| %>
       <% next unless ph["kind"] == "text" %>
 
-      <!-- ★ ここから追加：行IDと max_chars を取り出す -->
       <% line_id   = ph["id"] %>
       <% max_chars = ph.dig("constraints", "max_chars") %>
-      <!-- ★ ここまで追加 -->
 
       <!-- ★ ここから変更：ガイド枠だけの div → textarea を内包する絶対配置コンテナに変更 -->
       <div
@@ -42,18 +40,38 @@
               id: "letter_placeholders_#{line_id}_value",
               rows: 1,
               maxlength: max_chars,
+
+              data: {
+                action: "focus->text-style#select click->text-style#select",
+                "text-style-target": "line",
+                line_id: line_id,
+
+                default_font_family: ph["font_family"],
+                default_font_size: ph["font_size"],
+                default_color: ph["color"]
+              },
               class: "w-full h-full
                       border-0 border-b
                       bg-transparent
                       text-base text-stone-900
                       resize-none overflow-hidden
                       focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-sky-400",
-              style: "box-sizing: border-box,
-                      border-bottom-color: #000000,
-                      padding: 0 4px;"
+              style: "box-sizing: border-box;
+                      border-bottom-color: #000000;
+                      padding: 0 4px;
+                      font-family: #{ph["font_family"] || "Noto Sans JP"};
+                      font-size: #{(ph["font_size"] || 16).to_i}px;
+                      color: #{ph["color"] || "#000000"};"
             ) %>
+        <%= hidden_field_tag "letter[placeholders][#{line_id}][overrides][font_family]", "",
+            data: { "text-style-target": "hiddenFontFamily", line_id: line_id } %>
+
+        <%= hidden_field_tag "letter[placeholders][#{line_id}][overrides][font_size]", "",
+            data: { "text-style-target": "hiddenFontSize", line_id: line_id } %>
+
+        <%= hidden_field_tag "letter[placeholders][#{line_id}][overrides][color]", "",
+            data: { "text-style-target": "hiddenColor", line_id: line_id } %>
       </div>
-      <!-- ★ ここまで変更 -->
     <% end %>
   </div>
 </div>

--- a/app/views/letters/_show_preview_canvas.html.erb
+++ b/app/views/letters/_show_preview_canvas.html.erb
@@ -27,6 +27,15 @@
       <% value = body_placeholders.dig(line_id, "value").to_s %>
       <% max_chars = ph.dig("constraints", "max_chars") %>
 
+      <!-- ✅ 追加：overrides を取得（なければ空Hash） -->
+      <% overrides = body_placeholders.dig(line_id, "overrides") %>
+      <% overrides = overrides.is_a?(Hash) ? overrides : {} %>
+
+      <!-- ✅ 追加：テンプレ default + overrides をマージして最終値を作る -->
+      <% font_family = overrides["font_family"].presence || ph["font_family"] || "Noto Sans JP" %>
+      <% font_size   = (overrides["font_size"].presence || ph["font_size"] || 16).to_i %>
+      <% color       = overrides["color"].presence || ph["color"] || "#000000" %>
+
 
       <!-- ★ ここから変更：ガイド枠だけの div → textarea を内包する絶対配置コンテナに変更 -->
       <div
@@ -38,10 +47,12 @@
           height:<%= ph["height_scaled"] %>px;
         "
       >
-        <div  class="w-full h-full flex items-center border-b",
+        <div  class="w-full h-full flex items-center border-b"
               style="border-bottom-color: #000000;"
               >
-          <span>
+          <span style="font-family:'<%= font_family %>', 'Noto Sans JP', system-ui, sans-serif;
+             font-size:<%= font_size %>px;
+             color:<%= color %>;">
             <%= value %>
           </span>
         </div>

--- a/app/views/letters/new.html.erb
+++ b/app/views/letters/new.html.erb
@@ -6,30 +6,6 @@
 
     <div class="flex gap-6 items-start">
 
-      <!-- 左サイドバー：テキスト設定（中身は後続issueで本実装） -->
-      <aside class="flex-none w-64 bg-stone-100 border border-stone-200 rounded-md p-4 space-y-4">
-        <div>
-          <label class="block text-sm font-medium text-stone-700 mb-1">Text font</label>
-          <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>Noto Sans JP(標準)</option>
-          </select>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-stone-700 mb-1">Text size</label>
-          <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>16px(標準)</option>
-          </select>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-stone-700 mb-1">Text color</label>
-          <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white">
-            <option>黒(標準)</option>
-          </select>
-        </div>
-      </aside>
-
       <!-- メインエリア：ここを form_with で丸ごとフォームにする -->
       <div class="flex-1 bg-white border border-stone-200 rounded-md p-6 space-y-6">
 
@@ -58,12 +34,54 @@
                           class: "inline-flex items-center px-4 py-1.5 rounded-md border border-stone-300 text-sm text-stone-700 hover:bg-stone-50" %>
             </div>
           </div>
-
-          <!-- 入力/プレビュー枠（★ ここが textarea オーバーレイ付きプレビュー） -->
-          <div class="mt-6">
-            <%= render "preview_canvas" %>
+          <!-- キャンパス+パネルの並びにする  -->
+          <div class="mt-6 flex gap-6 items-start" data-controller="text-style">
+              <div class="flex-1">
+                <%= render "preview_canvas"%>
+              </div>
+            <aside class="w-72 shrink-0 rounded-md border border-stone-200 bg-stone-50 p-4">
+              <h2 class="text-sm font-semibold text-stone-800 mb-2">文字スタイル</h2>
+              <p class="text-xs text-stone-600 mb-4" data-text-style-target="help">
+                行をクリックして選択し、文字スタイル（フォント・サイズ・色）を変更してください。
+              </p>
+              <div class="space-y-3 opacity-50 pointer-events-none" data-text-style-target="panel">
+                  <div>
+                    <label class="block text-xs font-medium text-stone-700 mb-1">フォント</label>
+                    <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white"
+                            data-text-style-target="fontFamily"
+                            data-action="change->text-style#apply">
+                      <option value="Noto Sans JP">Noto Sans JP</option>
+                      <option value="Noto Serif JP">Noto Serif JP</option>
+                      <option value="serif">Serif</option>
+                    </select>
+                  </div>
+                <div>
+                    <label class="block text-xs font-medium text-stone-700 mb-1">サイズ</label>
+                    <select class="w-full border border-stone-300 rounded-md text-sm px-2 py-1 bg-white"
+                            data-text-style-target="fontSize"
+                            data-action="change->text-style#apply">
+                      <option value="14">14</option>
+                      <option value="16" selected>16</option>
+                      <option value="18">18</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                <div>
+                  <label class="block text-xs font-medium text-stone-700 mb-1">色</label>
+                  <input type="color"
+                        class="w-full h-10 border border-stone-300 rounded-md bg-white"
+                        data-text-style-target="color"
+                        data-action="input->text-style#apply"
+                        value="#000000">
+                </div>
+                <button type="button"
+                        class="w-full mt-2 px-3 py-2 text-sm rounded-md border border-stone-300 hover:bg-white"
+                        data-action="click->text-style#reset">
+                  選択行をデフォルトに戻す
+                </button>
+              </div>
+            </aside>
           </div>
-
           <!-- 手紙情報フォーム -->
           <div class="mt-6 space-y-4">
 


### PR DESCRIPTION
### 実装手順

1. 手紙作成画面：左サイドバー削除
2. キャンバス横に「文字スタイル」パネルを追加
3. textarea(行)をクリックすると「選択中」になる(見た目強調）
4. パネルでフォント/文字サイズ/色を帰ると、選択中の行だけ反映
5. 変更内容はhidden fieldに入れてフォーム送信
6. Letterモデルがbody[”placeholders”][”line_id”][”overrides”]に保存
7. show/受信プレビューの表示でoverridesを反映

ここまで実装したところ、手紙作成画面では適切にスタイル変更ができたが、詳細ページと受信ページでは反映されていなかった。
次のissueで微修正を行う。